### PR TITLE
VS2015 build support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,9 @@ X-build/output/
 3rdparty/zlib*
 Thumbs.db
 
+windows-build/visual-studio-2015/.vs
 windows-build/visual-studio-2015/Debug
 windows-build/visual-studio-2015/Release
 windows-build/visual-studio-2015/*.db
 windows-build/visual-studio-2015/*.opendb
-
+windows-build/visual-studio-2015/*.user

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,9 @@ X-build/output/
 3rdparty/unrarlib*
 3rdparty/zlib*
 Thumbs.db
+
+windows-build/visual-studio-2015/Debug
+windows-build/visual-studio-2015/Release
+windows-build/visual-studio-2015/*.db
+windows-build/visual-studio-2015/*.opendb
+

--- a/steem/Steem.cpp
+++ b/steem/Steem.cpp
@@ -192,9 +192,6 @@ USEFILE("code\midi.cpp");
 
 USERC("rc\resource.rc");
 //---------------------------------------------------------------------------
-#define IN_MAIN
-
-#include "conditions.h"
 
 #include "main.cpp"
 

--- a/steem/code/cpu.cpp
+++ b/steem/code/cpu.cpp
@@ -747,7 +747,7 @@ LONG m68k_read_dest_l(){
   DEBUG_ONLY( debug_first_instruction=0 );
 
 #define LOGSECTION LOGSECTION_TRACE
-extern "C" ASMCALL void m68k_trace() //execute instruction with trace bit set
+extern "C" void ASMCALL m68k_trace() //execute instruction with trace bit set
 {
 #ifdef _DEBUG_BUILD
   pc_history[pc_history_idx++]=pc;

--- a/steem/code/gui.h
+++ b/steem/code/gui.h
@@ -17,7 +17,7 @@
 #define PEEKED_NOTHING 2
 #define PEEKED_RUN 3
 
-extern "C" ASMCALL int PeekEvent();
+extern "C" int ASMCALL PeekEvent();
 
 UNIX_ONLY( EXT void PostRunMessage(); )
 

--- a/windows-build/visual-studio-2015/Steem.sln
+++ b/windows-build/visual-studio-2015/Steem.sln
@@ -1,0 +1,21 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Steem", "vc.vcxproj", "{AA134E4C-83E8-4BCA-85C1-A9776193F442}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x86 = Debug|x86
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{AA134E4C-83E8-4BCA-85C1-A9776193F442}.Debug|x86.ActiveCfg = Debug|Win32
+		{AA134E4C-83E8-4BCA-85C1-A9776193F442}.Debug|x86.Build.0 = Debug|Win32
+		{AA134E4C-83E8-4BCA-85C1-A9776193F442}.Release|x86.ActiveCfg = Release|Win32
+		{AA134E4C-83E8-4BCA-85C1-A9776193F442}.Release|x86.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/windows-build/visual-studio-2015/vc.vcxproj
+++ b/windows-build/visual-studio-2015/vc.vcxproj
@@ -1,0 +1,116 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectName>Steem</ProjectName>
+    <ProjectGuid>{AA134E4C-83E8-4BCA-85C1-A9776193F442}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <_ProjectFileVersion>14.0.25420.1</_ProjectFileVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <OutDir>Debug\</OutDir>
+    <IntDir>Debug\</IntDir>
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <OutDir>Release\</OutDir>
+    <IntDir>Release\</IntDir>
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>$(ProjectDir)..\..\3rdparty;$(ProjectDir)..\..\include;$(ProjectDir)..\..\steem\code;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_VC_BUILD;WIN32;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MinimalRebuild>true</MinimalRebuild>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <PrecompiledHeader />
+      <WarningLevel>TurnOffAllWarnings</WarningLevel>
+      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>dinput.lib;dxguid.lib;winmm.lib;ComCtl32.Lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)Steem.exe</OutputFile>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <ProgramDatabaseFile>$(OutDir)vc.pdb</ProgramDatabaseFile>
+      <SubSystem>Windows</SubSystem>
+      <TargetMachine>MachineX86</TargetMachine>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <Optimization>Full</Optimization>
+      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <OmitFramePointers>true</OmitFramePointers>
+      <AdditionalIncludeDirectories>$(ProjectDir)..\..\3rdparty;$(ProjectDir)..\..\include;$(ProjectDir)..\..\steem\code;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_VC_BUILD;WIN32;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <StringPooling>true</StringPooling>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <PrecompiledHeader />
+      <WarningLevel>TurnOffAllWarnings</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>dinput.lib;dxguid.lib;winmm.lib;ComCtl32.Lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)Steem.exe</OutputFile>
+      <GenerateDebugInformation>false</GenerateDebugInformation>
+      <SubSystem>Windows</SubSystem>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <TargetMachine>MachineX86</TargetMachine>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\3rdparty\unrarlib\unrarlib.c" />
+    <ClCompile Include="..\..\steem\emu.cpp" />
+    <ClCompile Include="..\..\steem\helper.cpp" />
+    <ClCompile Include="..\..\steem\Steem.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <Object Include="..\..\..\include\asm\portio_vc.obj" />
+    <Object Include="..\asm\asm_draw_VC.obj" />
+    <Object Include="..\asm\asm_osd_VC.obj" />
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="..\..\steem\rc\resource.rc" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/windows-build/visual-studio-2015/vc.vcxproj
+++ b/windows-build/visual-studio-2015/vc.vcxproj
@@ -103,12 +103,25 @@
     <ClCompile Include="..\..\steem\Steem.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <Object Include="..\..\..\include\asm\portio_vc.obj" />
-    <Object Include="..\asm\asm_draw_VC.obj" />
-    <Object Include="..\asm\asm_osd_VC.obj" />
+    <ResourceCompile Include="..\..\steem\rc\resource.rc" />
   </ItemGroup>
   <ItemGroup>
-    <ResourceCompile Include="..\..\steem\rc\resource.rc" />
+    <CustomBuild Include="..\..\steem\asm\asm_draw.asm">
+      <FileType>Document</FileType>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">nasm -fwin32 -dWIN32 -d_VC_BUILD -i%(RelativeDir) -o$(IntermediateOutputPath)%(Filename).obj -w+macro-params -w+macro-selfref -w+orphan-labels %(Identity)</Command>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntermediateOutputPath)%(Filename).obj</Outputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">nasm -fwin32 -dWIN32 -d_VC_BUILD -i%(RelativeDir) -o$(IntermediateOutputPath)%(Filename).obj -w+macro-params -w+macro-selfref -w+orphan-labels %(Identity)</Command>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(IntermediateOutputPath)%(Filename).obj</Outputs>
+    </CustomBuild>
+  </ItemGroup>
+  <ItemGroup>
+    <CustomBuild Include="..\..\steem\asm\asm_osd_draw.asm">
+      <FileType>Document</FileType>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">nasm -fwin32 -dWIN32 -d_VC_BUILD -i%(RelativeDir) -o$(IntermediateOutputPath)%(Filename).obj -w+macro-params -w+macro-selfref -w+orphan-labels %(Identity)</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">nasm -fwin32 -dWIN32 -d_VC_BUILD -i%(RelativeDir) -o$(IntermediateOutputPath)%(Filename).obj -w+macro-params -w+macro-selfref -w+orphan-labels %(Identity)</Command>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntermediateOutputPath)%(Filename).obj</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(IntermediateOutputPath)%(Filename).obj</Outputs>
+    </CustomBuild>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/windows-build/visual-studio-2015/vc.vcxproj
+++ b/windows-build/visual-studio-2015/vc.vcxproj
@@ -62,7 +62,7 @@
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>dinput.lib;dxguid.lib;winmm.lib;ComCtl32.Lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>dxguid.lib;winmm.lib;ComCtl32.Lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)Steem.exe</OutputFile>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ProgramDatabaseFile>$(OutDir)vc.pdb</ProgramDatabaseFile>
@@ -87,7 +87,7 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>dinput.lib;dxguid.lib;winmm.lib;ComCtl32.Lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>dxguid.lib;winmm.lib;ComCtl32.Lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)Steem.exe</OutputFile>
       <GenerateDebugInformation>false</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>

--- a/windows-build/visual-studio-2015/vc.vcxproj.filters
+++ b/windows-build/visual-studio-2015/vc.vcxproj.filters
@@ -16,8 +16,8 @@
     <Filter Include="Third Party">
       <UniqueIdentifier>{d887cd2e-09f9-4842-9094-de5dc7673ae8}</UniqueIdentifier>
     </Filter>
-    <Filter Include="Object Files">
-      <UniqueIdentifier>{69df1f0e-f88d-4019-8457-c52ff183773c}</UniqueIdentifier>
+    <Filter Include="Assembly files">
+      <UniqueIdentifier>{f73d920e-cff2-43c6-880b-f724c56226ad}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>
@@ -35,19 +35,16 @@
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <Object Include="..\asm\asm_draw_VC.obj">
-      <Filter>Object Files</Filter>
-    </Object>
-    <Object Include="..\asm\asm_osd_VC.obj">
-      <Filter>Object Files</Filter>
-    </Object>
-    <Object Include="..\..\..\include\asm\portio_vc.obj">
-      <Filter>Object Files</Filter>
-    </Object>
-  </ItemGroup>
-  <ItemGroup>
     <ResourceCompile Include="..\..\steem\rc\resource.rc">
       <Filter>Resource Files</Filter>
     </ResourceCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <CustomBuild Include="..\..\steem\asm\asm_draw.asm">
+      <Filter>Assembly files</Filter>
+    </CustomBuild>
+    <CustomBuild Include="..\..\steem\asm\asm_osd_draw.asm">
+      <Filter>Assembly files</Filter>
+    </CustomBuild>
   </ItemGroup>
 </Project>

--- a/windows-build/visual-studio-2015/vc.vcxproj.filters
+++ b/windows-build/visual-studio-2015/vc.vcxproj.filters
@@ -1,0 +1,53 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{66ff2e4e-9f04-42d7-a207-e57ce4bd3011}</UniqueIdentifier>
+      <Extensions>cpp;c;cxx;def;odl;idl;hpj;bat;asm</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{033f7cc2-97ee-4a38-8646-c68342b0fc7e}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{e17e270b-6fe9-4459-ba56-8ff34d180baa}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe</Extensions>
+    </Filter>
+    <Filter Include="Third Party">
+      <UniqueIdentifier>{d887cd2e-09f9-4842-9094-de5dc7673ae8}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Object Files">
+      <UniqueIdentifier>{69df1f0e-f88d-4019-8457-c52ff183773c}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\steem\emu.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\steem\helper.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\steem\Steem.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\3rdparty\unrarlib\unrarlib.c">
+      <Filter>Third Party</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <Object Include="..\asm\asm_draw_VC.obj">
+      <Filter>Object Files</Filter>
+    </Object>
+    <Object Include="..\asm\asm_osd_VC.obj">
+      <Filter>Object Files</Filter>
+    </Object>
+    <Object Include="..\..\..\include\asm\portio_vc.obj">
+      <Filter>Object Files</Filter>
+    </Object>
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="..\..\steem\rc\resource.rc">
+      <Filter>Resource Files</Filter>
+    </ResourceCompile>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
I have made the latest version of Steem Engine possible to build with VS 2015. The old VS project remains in there as well. I have only tried building this with VS 2015; none of the other supported compilers.

(Side note: the file paths in the old VS project seem to be outdated. Unless you plan to use it to build for old Windowses, I suggest it's time to remove the windows-build/visual-studio/ folder.)

 Is this something that you are interested in including with the mainline?
